### PR TITLE
Use tweet_mode=extended and full_text for rendering tweets that contain more than 140 characters.

### DIFF
--- a/t2h.rb
+++ b/t2h.rb
@@ -18,6 +18,7 @@ module TweetsToHtml
       res = t.statuses_user_timeline({
         'screen_name' => params.screen_name,
         'count' => params.count,
+        'tweet_mode' => 'extended'
       })
 
       statuses = JSON.parse(res.body)
@@ -42,9 +43,9 @@ module TweetsToHtml
 
     def create_body(status)
       if status['retweeted_status']
-        body = CGI.escapeHTML("RT @#{status['retweeted_status']['user']['screen_name']}\n#{status['retweeted_status']['text']}")
+        body = CGI.escapeHTML("RT @#{status['retweeted_status']['user']['screen_name']}\n#{status['retweeted_status']['full_text']}")
       else
-        body = CGI.escapeHTML(status['text'])
+        body = CGI.escapeHTML(status['full_text'])
       end
       body = body.gsub(/\n/, '<br>')
       body = body.gsub(/ /, '&nbsp;')


### PR DESCRIPTION
Use tweet_mode=extended and full_text for rendering tweets that contain more than 140 characters.

Giving you more characters to express yourself
https://blog.twitter.com/official/en_us/topics/product/2017/Giving-you-more-characters-to-express-yourself.html

> We want every person around the world to easily express themselves on Twitter, so we're doing something new: we're going to try out a longer limit, 280 characters, in languages impacted by cramming (which is all except Japanese, Chinese, and Korean).

Tweet updates — Twitter Developers
https://developer.twitter.com/en/docs/tweets/tweet-updates

> Tweet payload contains all information to render Tweets that contain more than 140 characters

> REST APIs only: add the below parameters to any endpoint:
> tweet_mode=extended

> full_text replaces text